### PR TITLE
validateHeader to validateEthHeaderCompatibility and skip all boundar…

### DIFF
--- a/blockchain/types/tx_internal_data_account_creation.go
+++ b/blockchain/types/tx_internal_data_account_creation.go
@@ -454,7 +454,7 @@ func (t *TxInternalDataAccountCreation) Validate(stateDB StateDB, currentBlockNu
 	//if t.HumanReadable {
 	//	return kerrors.ErrHumanReadableNotSupported
 	//}
-	//if common.IsPrecompiledContractAddress(t.Recipient) {
+	//if common.IsPrecompiledContractAddress(t.Recipient, fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 	//	return kerrors.ErrPrecompiledContractAddress
 	//}
 	//if err := t.Key.CheckInstallable(currentBlockNumber); err != nil {

--- a/blockchain/types/tx_internal_data_ethereum_access_list.go
+++ b/blockchain/types/tx_internal_data_ethereum_access_list.go
@@ -429,7 +429,7 @@ func (t *TxInternalDataEthereumAccessList) String() string {
 
 func (t *TxInternalDataEthereumAccessList) Validate(stateDB StateDB, currentBlockNumber uint64) error {
 	if t.Recipient != nil {
-		if common.IsPrecompiledContractAddress(*t.Recipient) {
+		if common.IsPrecompiledContractAddress(*t.Recipient, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 			return kerrors.ErrPrecompiledContractAddress
 		}
 	}

--- a/blockchain/types/tx_internal_data_ethereum_dynamic_fee.go
+++ b/blockchain/types/tx_internal_data_ethereum_dynamic_fee.go
@@ -425,7 +425,7 @@ func (t *TxInternalDataEthereumDynamicFee) SenderTxHash() common.Hash {
 
 func (t *TxInternalDataEthereumDynamicFee) Validate(stateDB StateDB, currentBlockNumber uint64) error {
 	if t.Recipient != nil {
-		if common.IsPrecompiledContractAddress(*t.Recipient) {
+		if common.IsPrecompiledContractAddress(*t.Recipient, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 			return kerrors.ErrPrecompiledContractAddress
 		}
 	}

--- a/blockchain/types/tx_internal_data_ethereum_set_code.go
+++ b/blockchain/types/tx_internal_data_ethereum_set_code.go
@@ -407,7 +407,7 @@ func (t *TxInternalDataEthereumSetCode) Validate(stateDB StateDB, currentBlockNu
 	if t.Recipient == (common.Address{}) {
 		return kerrors.ErrEmptyRecipient
 	} else {
-		if common.IsPrecompiledContractAddress(t.Recipient) {
+		if common.IsPrecompiledContractAddress(t.Recipient, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 			return kerrors.ErrPrecompiledContractAddress
 		}
 	}

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy.go
@@ -391,7 +391,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractDeploy) Validate(stateDB StateDB
 	} else {
 		to = crypto.CreateAddress(t.From, t.AccountNonce)
 	}
-	if common.IsPrecompiledContractAddress(to) {
+	if common.IsPrecompiledContractAddress(to, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 		return kerrors.ErrPrecompiledContractAddress
 	}
 	if t.HumanReadable {

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy_with_ratio.go
@@ -415,7 +415,7 @@ func (t *TxInternalDataFeeDelegatedSmartContractDeployWithRatio) Validate(stateD
 	} else {
 		to = crypto.CreateAddress(t.From, t.AccountNonce)
 	}
-	if common.IsPrecompiledContractAddress(to) {
+	if common.IsPrecompiledContractAddress(to, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 		return kerrors.ErrPrecompiledContractAddress
 	}
 	if t.HumanReadable {

--- a/blockchain/types/tx_internal_data_fee_delegated_value_transfer.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_value_transfer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/crypto/sha3"
+	"github.com/kaiachain/kaia/fork"
 	"github.com/kaiachain/kaia/kerrors"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
@@ -316,7 +317,7 @@ func (t *TxInternalDataFeeDelegatedValueTransfer) SenderTxHash() common.Hash {
 }
 
 func (t *TxInternalDataFeeDelegatedValueTransfer) Validate(stateDB StateDB, currentBlockNumber uint64) error {
-	if common.IsPrecompiledContractAddress(t.Recipient) {
+	if common.IsPrecompiledContractAddress(t.Recipient, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 		return kerrors.ErrPrecompiledContractAddress
 	}
 	return t.ValidateMutableValue(stateDB, currentBlockNumber)

--- a/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo.go
@@ -343,7 +343,7 @@ func (t *TxInternalDataFeeDelegatedValueTransferMemo) SenderTxHash() common.Hash
 }
 
 func (t *TxInternalDataFeeDelegatedValueTransferMemo) Validate(stateDB StateDB, currentBlockNumber uint64) error {
-	if common.IsPrecompiledContractAddress(t.Recipient) {
+	if common.IsPrecompiledContractAddress(t.Recipient, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 		return kerrors.ErrPrecompiledContractAddress
 	}
 	return t.ValidateMutableValue(stateDB, currentBlockNumber)

--- a/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_value_transfer_memo_with_ratio.go
@@ -367,7 +367,7 @@ func (t *TxInternalDataFeeDelegatedValueTransferMemoWithRatio) SenderTxHash() co
 }
 
 func (t *TxInternalDataFeeDelegatedValueTransferMemoWithRatio) Validate(stateDB StateDB, currentBlockNumber uint64) error {
-	if common.IsPrecompiledContractAddress(t.Recipient) {
+	if common.IsPrecompiledContractAddress(t.Recipient, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 		return kerrors.ErrPrecompiledContractAddress
 	}
 	return t.ValidateMutableValue(stateDB, currentBlockNumber)

--- a/blockchain/types/tx_internal_data_fee_delegated_value_transfer_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_value_transfer_with_ratio.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/crypto/sha3"
+	"github.com/kaiachain/kaia/fork"
 	"github.com/kaiachain/kaia/kerrors"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
@@ -338,7 +339,7 @@ func (t *TxInternalDataFeeDelegatedValueTransferWithRatio) SenderTxHash() common
 }
 
 func (t *TxInternalDataFeeDelegatedValueTransferWithRatio) Validate(stateDB StateDB, currentBlockNumber uint64) error {
-	if common.IsPrecompiledContractAddress(t.Recipient) {
+	if common.IsPrecompiledContractAddress(t.Recipient, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 		return kerrors.ErrPrecompiledContractAddress
 	}
 	return t.ValidateMutableValue(stateDB, currentBlockNumber)

--- a/blockchain/types/tx_internal_data_legacy.go
+++ b/blockchain/types/tx_internal_data_legacy.go
@@ -361,7 +361,8 @@ func (t *TxInternalDataLegacy) String() string {
 
 func (t *TxInternalDataLegacy) Validate(stateDB StateDB, currentBlockNumber uint64) error {
 	if t.Recipient != nil {
-		if common.IsPrecompiledContractAddress(*t.Recipient) {
+		fmt.Println(fork.Rules(big.NewInt(int64(currentBlockNumber))))
+		if common.IsPrecompiledContractAddress(*t.Recipient, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 			return kerrors.ErrPrecompiledContractAddress
 		}
 	}

--- a/blockchain/types/tx_internal_data_smart_contract_deploy.go
+++ b/blockchain/types/tx_internal_data_smart_contract_deploy.go
@@ -356,7 +356,7 @@ func (t *TxInternalDataSmartContractDeploy) Validate(stateDB StateDB, currentBlo
 	} else {
 		to = crypto.CreateAddress(t.From, t.AccountNonce)
 	}
-	if common.IsPrecompiledContractAddress(to) {
+	if common.IsPrecompiledContractAddress(to, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 		return kerrors.ErrPrecompiledContractAddress
 	}
 	if t.HumanReadable {

--- a/blockchain/types/tx_internal_data_value_transfer.go
+++ b/blockchain/types/tx_internal_data_value_transfer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/crypto/sha3"
+	"github.com/kaiachain/kaia/fork"
 	"github.com/kaiachain/kaia/kerrors"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
@@ -284,7 +285,7 @@ func (t *TxInternalDataValueTransfer) SenderTxHash() common.Hash {
 }
 
 func (t *TxInternalDataValueTransfer) Validate(stateDB StateDB, currentBlockNumber uint64) error {
-	if common.IsPrecompiledContractAddress(t.Recipient) {
+	if common.IsPrecompiledContractAddress(t.Recipient, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 		return kerrors.ErrPrecompiledContractAddress
 	}
 	return t.ValidateMutableValue(stateDB, currentBlockNumber)

--- a/blockchain/types/tx_internal_data_value_transfer_memo.go
+++ b/blockchain/types/tx_internal_data_value_transfer_memo.go
@@ -308,7 +308,7 @@ func (t *TxInternalDataValueTransferMemo) SenderTxHash() common.Hash {
 }
 
 func (t *TxInternalDataValueTransferMemo) Validate(stateDB StateDB, currentBlockNumber uint64) error {
-	if common.IsPrecompiledContractAddress(t.Recipient) {
+	if common.IsPrecompiledContractAddress(t.Recipient, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
 		return kerrors.ErrPrecompiledContractAddress
 	}
 	return t.ValidateMutableValue(stateDB, currentBlockNumber)

--- a/blockchain/vm/contracts.go
+++ b/blockchain/vm/contracts.go
@@ -23,7 +23,6 @@
 package vm
 
 import (
-	"bytes"
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"encoding/binary"
@@ -215,31 +214,6 @@ func ActivePrecompiles(rules params.Rules) []common.Address {
 	} else {
 		return precompiledContractAddrs
 	}
-}
-
-// IsPrecompiledContractAddress returns true if this is used for TestExecutionSpecState and the input address is one of precompiled contract addresses.
-func IsPrecompiledContractAddress(addr common.Address, rules params.Rules) bool {
-	if relaxPrecompileRangeForTest {
-		activePrecompiles := ActivePrecompiles(rules)
-		for _, pre := range activePrecompiles {
-			// skip 0x0a and 0x0b if before Prague
-			if !rules.IsPrague && (bytes.Compare(pre.Bytes(), []byte{10}) == 0 || bytes.Compare(pre.Bytes(), []byte{11}) == 0) {
-				continue
-			}
-			if bytes.Compare(pre.Bytes(), addr.Bytes()) == 0 {
-				return true
-			}
-		}
-		return false
-	}
-	return common.IsPrecompiledContractAddress(addr)
-}
-
-var relaxPrecompileRangeForTest bool
-
-// Only for testing. Make sure to reset (false) after test.
-func RelaxPrecompileRangeForTest(enable bool) {
-	relaxPrecompileRangeForTest = enable
 }
 
 // RunPrecompiledContract runs and evaluates the output of a precompiled contract.

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -256,7 +256,7 @@ func (evm *EVM) Call(caller types.ContractRef, addr common.Address, input []byte
 	)
 
 	// Filter out invalid precompiled address calls, and create a precompiled contract object if it is not exist.
-	if IsPrecompiledContractAddress(addr, evm.chainRules) {
+	if common.IsPrecompiledContractAddress(addr, evm.chainRules) {
 		precompiles := evm.GetPrecompiledContractMap(caller.Address())
 		if precompiles[addr] == nil || value.Sign() != 0 {
 			// Return an error if an enabled precompiled address is called or a value is transferred to a precompiled address.
@@ -527,7 +527,7 @@ func (evm *EVM) create(caller types.ContractRef, codeAndHash *codeAndHash, gas u
 		return nil, common.Address{}, 0, ErrContractAddressCollision
 	}
 
-	if IsPrecompiledContractAddress(address, evm.chainRules) {
+	if common.IsPrecompiledContractAddress(address, evm.chainRules) {
 		return nil, common.Address{}, gas, kerrors.ErrPrecompiledContractAddress
 	}
 

--- a/common/types.go
+++ b/common/types.go
@@ -353,10 +353,8 @@ func BigToAddress(b *big.Int) Address { return BytesToAddress(b.Bytes()) }
 // If s is larger than len(h), s will be cropped from the left.
 func HexToAddress(s string) Address { return BytesToAddress(FromHex(s)) }
 
-var relaxPrecompileRangeForTest bool
-
 // IsPrecompiledContractAddress returns true if the input address is in the range of precompiled contract addresses.
-func IsPrecompiledContractAddress(addr Address) bool {
+var IsPrecompiledContractAddress func(addr Address, rules interface{}) bool = func(addr Address, rules interface{}) bool {
 	if bytes.Compare(addr.Bytes(), lastPrecompiledContractAddressHex) > 0 || addr == (Address{}) {
 		return false
 	}

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -25,7 +25,6 @@ package tests
 import (
 	"testing"
 
-	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/stretchr/testify/suite"
 )
@@ -74,17 +73,18 @@ func TestBlockchain(t *testing.T) {
 // }
 
 // TestExecutionSpecState runs the state_test fixtures from execution-spec-tests.
-
 type ExecutionSpecBlockTestSuite struct {
 	suite.Suite
+	originalIsPrecompiledContractAddress func(common.Address, interface{}) bool
 }
 
 func (suite *ExecutionSpecBlockTestSuite) SetupSuite() {
-	vm.RelaxPrecompileRangeForTest(true)
+	suite.originalIsPrecompiledContractAddress = common.IsPrecompiledContractAddress
+	common.IsPrecompiledContractAddress = isPrecompiledContractAddressForEthTest
 }
 
 func (suite *ExecutionSpecBlockTestSuite) TearDownSuite() {
-	vm.RelaxPrecompileRangeForTest(false)
+	common.IsPrecompiledContractAddress = suite.originalIsPrecompiledContractAddress
 }
 
 func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -127,7 +127,7 @@ func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {
 	bt.skipLoad(`^cancun\/eip7516_blobgasfee\/`)
 
 	bt.walk(t, executionSpecBlockTestDir, func(t *testing.T, name string, test *BlockTest) {
-		boundaryValueTests := []string{"ShanghaiToCancunAtTime15k"}
+		boundaryValueTests := []string{"ParisToShanghaiAtTime15k", "ShanghaiToCancunAtTime15k", "CancunToPragueAtTime15k"}
 		for _, boundaryValueTest := range boundaryValueTests {
 			if test.json.Network == boundaryValueTest {
 				t.Skip()

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -105,12 +105,13 @@ func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {
 	bt.skipLoad(`^berlin\/`)
 	bt.skipLoad(`^byzantium\/`)
 	// bt.skipLoad(`^cancun\/`)
-	bt.skipLoad(`^cancun\/eip1153_tstore\/tload.*\/`)
-	bt.skipLoad(`^cancun\/eip1153_tstore\/tstorage.*\/`)
-	bt.skipLoad(`^cancun\/eip1153_tstore\/tstore_reentrancy\/`)
-	bt.skipLoad(`^cancun\/eip5656_mcopy\/`)
+	// bt.skipLoad(`^cancun\/eip1153_tstore\/basic_tload.*\/`)
+	// bt.skipLoad(`^cancun\/eip1153_tstore\/tload_calls.*\/`)
+	// bt.skipLoad(`^cancun\/eip1153_tstore\/tstorage.*\/`)
+	// bt.skipLoad(`^cancun\/eip1153_tstore\/tstore_reentrancy\/`)
+	// bt.skipLoad(`^cancun\/eip5656_mcopy\/`)
 	bt.skipLoad(`^cancun\/eip6780_selfdestruct\/`)
-	bt.skipLoad(`^cancun\/eip7516_blobgasfee\/`)
+	
 	bt.skipLoad(`^constantinople\/`)
 	bt.skipLoad(`^frontier\/`)
 	bt.skipLoad(`^homestead\/`)
@@ -123,8 +124,16 @@ func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {
 	// unsupported EIPs
 	bt.skipLoad(`^cancun\/eip4788_beacon_root\/`)
 	bt.skipLoad(`^cancun\/eip4844_blobs\/`)
+	bt.skipLoad(`^cancun\/eip7516_blobgasfee\/`)
 
 	bt.walk(t, executionSpecBlockTestDir, func(t *testing.T, name string, test *BlockTest) {
+		boundaryValueTests := []string{"ShanghaiToCancunAtTime15k"}
+		for _, boundaryValueTest := range boundaryValueTests {
+			if test.json.Network == boundaryValueTest {
+				t.Skip()
+			}
+		}
+
 		if err := bt.checkFailure(t, name, test.Run()); err != nil {
 			t.Error(err)
 		}

--- a/tests/gen_btheader.go
+++ b/tests/gen_btheader.go
@@ -17,47 +17,77 @@ var _ = (*btHeaderMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (b btHeader) MarshalJSON() ([]byte, error) {
 	type btHeader struct {
-		Bloom            types.Bloom
-		Number           *math.HexOrDecimal256
-		Hash             common.Hash
-		ParentHash       common.Hash
-		ReceiptTrie      common.Hash
-		StateRoot        common.Hash
-		TransactionsTrie common.Hash
-		ExtraData        hexutil.Bytes
-		BlockScore       *math.HexOrDecimal256
-		GasUsed          math.HexOrDecimal64
-		Timestamp        *math.HexOrDecimal256
+		Bloom                 types.Bloom
+		Coinbase              common.Address
+		MixHash               common.Hash
+		Nonce                 math.HexOrDecimal64
+		Number                *math.HexOrDecimal256
+		Hash                  common.Hash
+		ParentHash            common.Hash
+		ReceiptTrie           common.Hash
+		StateRoot             common.Hash
+		TransactionsTrie      common.Hash
+		UncleHash             common.Hash
+		ExtraData             hexutil.Bytes
+		Difficulty            *math.HexOrDecimal256
+		GasLimit              math.HexOrDecimal64
+		GasUsed               math.HexOrDecimal64
+		Timestamp             math.HexOrDecimal64
+		BaseFeePerGas         *math.HexOrDecimal256
+		WithdrawalsRoot       *common.Hash
+		BlobGasUsed           *math.HexOrDecimal64
+		ExcessBlobGas         *math.HexOrDecimal64
+		ParentBeaconBlockRoot *common.Hash
 	}
 	var enc btHeader
 	enc.Bloom = b.Bloom
+	enc.Coinbase = b.Coinbase
+	enc.MixHash = b.MixHash
+	enc.Nonce = math.HexOrDecimal64(b.Nonce)
 	enc.Number = (*math.HexOrDecimal256)(b.Number)
 	enc.Hash = b.Hash
 	enc.ParentHash = b.ParentHash
 	enc.ReceiptTrie = b.ReceiptTrie
 	enc.StateRoot = b.StateRoot
 	enc.TransactionsTrie = b.TransactionsTrie
+	enc.UncleHash = b.UncleHash
 	enc.ExtraData = b.ExtraData
-	enc.BlockScore = (*math.HexOrDecimal256)(b.BlockScore)
+	enc.Difficulty = (*math.HexOrDecimal256)(b.Difficulty)
+	enc.GasLimit = math.HexOrDecimal64(b.GasLimit)
 	enc.GasUsed = math.HexOrDecimal64(b.GasUsed)
-	enc.Timestamp = (*math.HexOrDecimal256)(b.Timestamp)
+	enc.Timestamp = math.HexOrDecimal64(b.Timestamp)
+	enc.BaseFeePerGas = (*math.HexOrDecimal256)(b.BaseFeePerGas)
+	enc.WithdrawalsRoot = b.WithdrawalsRoot
+	enc.BlobGasUsed = (*math.HexOrDecimal64)(b.BlobGasUsed)
+	enc.ExcessBlobGas = (*math.HexOrDecimal64)(b.ExcessBlobGas)
+	enc.ParentBeaconBlockRoot = b.ParentBeaconBlockRoot
 	return json.Marshal(&enc)
 }
 
 // UnmarshalJSON unmarshals from JSON.
 func (b *btHeader) UnmarshalJSON(input []byte) error {
 	type btHeader struct {
-		Bloom            *types.Bloom
-		Number           *math.HexOrDecimal256
-		Hash             *common.Hash
-		ParentHash       *common.Hash
-		ReceiptTrie      *common.Hash
-		StateRoot        *common.Hash
-		TransactionsTrie *common.Hash
-		ExtraData        *hexutil.Bytes
-		BlockScore       *math.HexOrDecimal256
-		GasUsed          *math.HexOrDecimal64
-		Timestamp        *math.HexOrDecimal256
+		Bloom                 *types.Bloom
+		Coinbase              *common.Address
+		MixHash               *common.Hash
+		Nonce                 *math.HexOrDecimal64
+		Number                *math.HexOrDecimal256
+		Hash                  *common.Hash
+		ParentHash            *common.Hash
+		ReceiptTrie           *common.Hash
+		StateRoot             *common.Hash
+		TransactionsTrie      *common.Hash
+		UncleHash             *common.Hash
+		ExtraData             *hexutil.Bytes
+		Difficulty            *math.HexOrDecimal256
+		GasLimit              *math.HexOrDecimal64
+		GasUsed               *math.HexOrDecimal64
+		Timestamp             *math.HexOrDecimal64
+		BaseFeePerGas         *math.HexOrDecimal256
+		WithdrawalsRoot       *common.Hash
+		BlobGasUsed           *math.HexOrDecimal64
+		ExcessBlobGas         *math.HexOrDecimal64
+		ParentBeaconBlockRoot *common.Hash
 	}
 	var dec btHeader
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -65,6 +95,15 @@ func (b *btHeader) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Bloom != nil {
 		b.Bloom = *dec.Bloom
+	}
+	if dec.Coinbase != nil {
+		b.Coinbase = *dec.Coinbase
+	}
+	if dec.MixHash != nil {
+		b.MixHash = *dec.MixHash
+	}
+	if dec.Nonce != nil {
+		b.Nonce = uint64(*dec.Nonce)
 	}
 	if dec.Number != nil {
 		b.Number = (*big.Int)(dec.Number)
@@ -84,17 +123,38 @@ func (b *btHeader) UnmarshalJSON(input []byte) error {
 	if dec.TransactionsTrie != nil {
 		b.TransactionsTrie = *dec.TransactionsTrie
 	}
+	if dec.UncleHash != nil {
+		b.UncleHash = *dec.UncleHash
+	}
 	if dec.ExtraData != nil {
 		b.ExtraData = *dec.ExtraData
 	}
-	if dec.BlockScore != nil {
-		b.BlockScore = (*big.Int)(dec.BlockScore)
+	if dec.Difficulty != nil {
+		b.Difficulty = (*big.Int)(dec.Difficulty)
+	}
+	if dec.GasLimit != nil {
+		b.GasLimit = uint64(*dec.GasLimit)
 	}
 	if dec.GasUsed != nil {
 		b.GasUsed = uint64(*dec.GasUsed)
 	}
 	if dec.Timestamp != nil {
-		b.Timestamp = (*big.Int)(dec.Timestamp)
+		b.Timestamp = uint64(*dec.Timestamp)
+	}
+	if dec.BaseFeePerGas != nil {
+		b.BaseFeePerGas = (*big.Int)(dec.BaseFeePerGas)
+	}
+	if dec.WithdrawalsRoot != nil {
+		b.WithdrawalsRoot = dec.WithdrawalsRoot
+	}
+	if dec.BlobGasUsed != nil {
+		b.BlobGasUsed = (*uint64)(dec.BlobGasUsed)
+	}
+	if dec.ExcessBlobGas != nil {
+		b.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
+	}
+	if dec.ParentBeaconBlockRoot != nil {
+		b.ParentBeaconBlockRoot = dec.ParentBeaconBlockRoot
 	}
 	return nil
 }

--- a/tests/init.go
+++ b/tests/init.go
@@ -23,9 +23,12 @@
 package tests
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 
+	"github.com/kaiachain/kaia/blockchain/vm"
+	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/params"
 )
 
@@ -106,4 +109,23 @@ type UnsupportedForkError struct {
 
 func (e UnsupportedForkError) Error() string {
 	return fmt.Sprintf("unsupported fork %q", e.Name)
+}
+
+// IsPrecompiledContractAddressForEthTest returns true if this is used for TestExecutionSpecState and the input address is one of precompiled contract addresses.
+func isPrecompiledContractAddressForEthTest(addr common.Address, rules interface{}) bool {
+	r, ok := rules.(params.Rules)
+	if !ok {
+		panic("unexpected type of rules")
+	}
+	activePrecompiles := vm.ActivePrecompiles(r)
+	for _, pre := range activePrecompiles {
+		// skip 0x0a and 0x0b if before Prague
+		if !r.IsPrague && (bytes.Compare(pre.Bytes(), []byte{10}) == 0 || bytes.Compare(pre.Bytes(), []byte{11}) == 0) {
+			continue
+		}
+		if bytes.Compare(pre.Bytes(), addr.Bytes()) == 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -45,6 +45,7 @@ var (
 	vmTestDir                 = filepath.Join(baseDir, "VMTests")
 	rlpTestDir                = filepath.Join(baseDir, "RLPTests")
 	executionSpecStateTestDir = filepath.Join(".", "spec-tests", "fixtures", "state_tests")
+	executionSpecBlockTestDir = filepath.Join(".", "spec-tests", "fixtures", "blockchain_tests")
 )
 
 func readJSON(reader io.Reader, value interface{}) error {

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -69,14 +69,16 @@ func TestKaiaSpecState(t *testing.T) {
 
 type ExecutionSpecStateTestSuite struct {
 	suite.Suite
+	originalIsPrecompiledContractAddress func(common.Address, interface{}) bool
 }
 
 func (suite *ExecutionSpecStateTestSuite) SetupSuite() {
-	vm.RelaxPrecompileRangeForTest(true)
+	suite.originalIsPrecompiledContractAddress = common.IsPrecompiledContractAddress
+	common.IsPrecompiledContractAddress = isPrecompiledContractAddressForEthTest
 }
 
 func (suite *ExecutionSpecStateTestSuite) TearDownSuite() {
-	vm.RelaxPrecompileRangeForTest(false)
+	common.IsPrecompiledContractAddress = suite.originalIsPrecompiledContractAddress
 }
 
 func (suite *ExecutionSpecStateTestSuite) TestExecutionSpecState() {

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -305,7 +305,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, isTest
 	}
 
 	if err == nil && isTestExecutionSpecState {
-		useEthMiningReward(st, evm, &t.json.Tx, t.json.Env.BaseFee, result.UsedGas, txContext.GasPrice)
+		useEthMiningReward(st, evm.Context.Coinbase, &t.json.Tx, t.json.Env.BaseFee, result.UsedGas, txContext.GasPrice, rules)
 	}
 
 	root, _ = st.Commit(true)
@@ -503,8 +503,12 @@ func useEthIntrinsicGas(data []byte, accessList types.AccessList, authorizationL
 	return types.IntrinsicGas(data, accessList, authorizationList, contractCreation, r)
 }
 
-func useEthMiningReward(statedb *state.StateDB, evm *vm.EVM, tx *stTransaction, envBaseFee *big.Int, usedGas uint64, gasPrice *big.Int) {
-	rules := evm.ChainConfig().Rules(evm.Context.BlockNumber)
+func useEthMiningReward(statedb *state.StateDB, coinbase common.Address, tx *stTransaction, envBaseFee *big.Int, usedGas uint64, gasPrice *big.Int, rules params.Rules) {
+	fee := calculateEthMiningReward(gasPrice, tx.MaxFeePerGas, tx.MaxPriorityFeePerGas, envBaseFee, usedGas, rules)
+	statedb.AddBalance(coinbase, fee)
+}
+
+func calculateEthMiningReward(gasPrice, maxFeePerGas, maxPriorityFeePerGas, envBaseFee *big.Int, usedGas uint64, rules params.Rules) *big.Int {
 	effectiveTip := new(big.Int).Set(gasPrice)
 
 	// https://github.com/ethereum/go-ethereum/blob/v1.14.11/tests/state_test_util.go#L241-L249
@@ -516,12 +520,11 @@ func useEthMiningReward(statedb *state.StateDB, evm *vm.EVM, tx *stTransaction, 
 			// parent - 2 : 0xa as the basefee for 'this' context.
 			baseFee = big.NewInt(0x0a)
 		}
-		effectiveTip = math.BigMin(tx.MaxPriorityFeePerGas, new(big.Int).Sub(tx.MaxFeePerGas, baseFee))
+		effectiveTip = math.BigMin(maxPriorityFeePerGas, new(big.Int).Sub(maxFeePerGas, baseFee))
 	}
 
 	fee := new(big.Int).SetUint64(usedGas)
-	fee.Mul(fee, effectiveTip)
-	statedb.AddBalance(evm.Context.Coinbase, fee)
+	return fee.Mul(fee, effectiveTip)
 }
 
 func useEthStateRoot(statedb *state.StateDB) (common.Hash, error) {


### PR DESCRIPTION


## Proposed changes

- I changed validateHeader to validateEthHeaderCompatibility leaving only the fields that are compatible with ethereum.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
